### PR TITLE
Add loaders

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "react-horizontal-scrolling-menu": "^4.1.1",
         "react-indiana-drag-scroll": "^2.2.0",
         "react-redux": "^8.1.3",
+        "react-spinners": "^0.13.8",
         "sass": "^1.69.5",
         "sharp": "^0.32.6",
         "swr": "^2.2.4",
@@ -4275,6 +4276,15 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
     },
+    "node_modules/react-spinners": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/react-spinners/-/react-spinners-0.13.8.tgz",
+      "integrity": "sha512-3e+k56lUkPj0vb5NDXPVFAOkPC//XyhKPJjvcGjyMNPWsBKpplfeyialP74G7H7+It7KzhtET+MvGqbKgAqpZA==",
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -8286,6 +8296,12 @@
           "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
         }
       }
+    },
+    "react-spinners": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/react-spinners/-/react-spinners-0.13.8.tgz",
+      "integrity": "sha512-3e+k56lUkPj0vb5NDXPVFAOkPC//XyhKPJjvcGjyMNPWsBKpplfeyialP74G7H7+It7KzhtET+MvGqbKgAqpZA==",
+      "requires": {}
     },
     "read-cache": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react-horizontal-scrolling-menu": "^4.1.1",
     "react-indiana-drag-scroll": "^2.2.0",
     "react-redux": "^8.1.3",
+    "react-spinners": "^0.13.8",
     "sass": "^1.69.5",
     "sharp": "^0.32.6",
     "swr": "^2.2.4",

--- a/src/components/board/NoBoardOrEmptyBoard.tsx
+++ b/src/components/board/NoBoardOrEmptyBoard.tsx
@@ -1,7 +1,7 @@
 import { useDispatch, useSelector } from "react-redux";
+import AddIcon from "~/components/svg/AddIcon";
+import Button from "~/components/ui/Button";
 import { selectBoards, selectCurrentBoard } from "~/store/selectors";
-import Button from "../ui/Button";
-import AddIcon from "../svg/AddIcon";
 import { toggleAddBoardModal, toggleEditBoardModal } from "~/store/uiSlice";
 
 const NoBoardOrEmptyBoard = () => {

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -4,12 +4,14 @@ import { useRouter } from "next/router";
 import { useDispatch, useSelector } from "react-redux";
 
 import HeaderMenu from "~/components/header/HeaderMenu";
-import SidebarMobile from "~/components/sidebar/MobileSidebar";
+import MobileSidebar from "~/components/sidebar/MobileSidebar";
 import AddIcon from "~/components/svg/AddIcon";
 import BoardIcon from "~/components/svg/BoardIcon";
 import Logo from "~/components/svg/Logo";
 import SearchIcon from "~/components/svg/SearchIcon";
 import Button from "~/components/ui/Button";
+import Loader from "~/components/ui/Loader";
+import { useGetBoardsQuery } from "~/store/api";
 import { selectCurrentBoard, selectShowSidebar } from "~/store/selectors";
 import { toggleAddTaskModal, toggleSearch } from "~/store/uiSlice";
 
@@ -19,8 +21,9 @@ type HeaderProps = {
 };
 
 const Header: React.FC<HeaderProps> = ({ report, boardName }) => {
-  const dispatch = useDispatch();
   const router = useRouter();
+  const { isLoading } = useGetBoardsQuery();
+  const dispatch = useDispatch();
   const showSidebar = useSelector(selectShowSidebar);
   const currentBoard = useSelector(selectCurrentBoard);
 
@@ -42,13 +45,17 @@ const Header: React.FC<HeaderProps> = ({ report, boardName }) => {
         </Link>
       </div>
       <div className="flex w-full flex-1 items-center justify-between pl-4 md:pl-6 md:pr-2">
-        {!report && <SidebarMobile />}
+        {!report && <MobileSidebar />}
         <h1
           className={clsx("truncate capitalize md:block", !report && "hidden")}
         >
-          {report
-            ? `${boardName ?? "No Board"} Report Generated`
-            : currentBoard?.name ?? "No Boards"}
+          {report ? (
+            `${boardName ?? "No Board"} Report Generated`
+          ) : isLoading ? (
+            <Loader size={10} color="#635fc7" />
+          ) : (
+            currentBoard?.name ?? "No Boards"
+          )}
         </h1>
         <div className="flex items-center gap-1 md:gap-2.5">
           {report ? (

--- a/src/components/modal/AddBoard.tsx
+++ b/src/components/modal/AddBoard.tsx
@@ -4,6 +4,7 @@ import { useDispatch } from "react-redux";
 import AddIcon from "~/components/svg/AddIcon";
 import XIcon from "~/components/svg/XIcon";
 import Button from "~/components/ui/Button";
+import Loader from "~/components/ui/Loader";
 import { useCreateBoardMutation } from "~/store/api";
 import { setCurrentBoard } from "~/store/boardSlice";
 import { toggleAddBoardModal } from "~/store/uiSlice";
@@ -59,7 +60,8 @@ const AddBoard = () => {
 
   if (error) return <p>error</p>;
 
-  if (isLoading) return <p>Loading...</p>;
+  if (isLoading)
+    return <Loader message="Creating Board..." color="#635fc7" size={16} />;
 
   return (
     <div className="w-full space-y-6">

--- a/src/components/modal/AddTask.tsx
+++ b/src/components/modal/AddTask.tsx
@@ -4,13 +4,14 @@ import { useDispatch } from "react-redux";
 import AddIcon from "~/components/svg/AddIcon";
 import XIcon from "~/components/svg/XIcon";
 import Button from "~/components/ui/Button";
+import Loader from "~/components/ui/Loader";
 import Select from "~/components/ui/Select";
 import { useAddTaskMutation } from "~/store/api";
 import { toggleAddTaskModal } from "~/store/uiSlice";
 import type { CreateTaskInput } from "~/types";
 
 const AddTask: React.FC = () => {
-  const [addTask, { isLoading, error, data }] = useAddTaskMutation();
+  const [addTask, { isLoading, error }] = useAddTaskMutation();
   const dispatch = useDispatch();
 
   const {
@@ -56,7 +57,8 @@ const AddTask: React.FC = () => {
 
   if (error) return <p>Error</p>;
 
-  if (isLoading) return <p>Adding task...</p>;
+  if (isLoading)
+    return <Loader message="Creating Task..." color="#635fc7" size={16} />;
 
   return (
     <div className="w-full space-y-6">

--- a/src/components/modal/DeleteBoard.tsx
+++ b/src/components/modal/DeleteBoard.tsx
@@ -1,9 +1,10 @@
 import { useDispatch, useSelector } from "react-redux";
 
 import Button from "~/components/ui/Button";
+import Loader from "~/components/ui/Loader";
+import { useDeleteBoardMutation } from "~/store/api";
 import { selectCurrentBoard } from "~/store/selectors";
 import { toggleDeleteBoardModal } from "~/store/uiSlice";
-import { useDeleteBoardMutation } from "~/store/api";
 
 const DeleteBoard = () => {
   const [deleteBoard, { isLoading, error }] = useDeleteBoardMutation();
@@ -21,7 +22,8 @@ const DeleteBoard = () => {
 
   if (error) return <p>Error</p>;
 
-  if (isLoading) return <p>Deleting...</p>;
+  if (isLoading)
+    return <Loader message="Deleting Board..." color="#635fc7" size={16} />;
 
   return (
     <div className="flex flex-col gap-6">

--- a/src/components/modal/DeleteTask.tsx
+++ b/src/components/modal/DeleteTask.tsx
@@ -1,15 +1,15 @@
 import { useDispatch, useSelector } from "react-redux";
 
 import Button from "~/components/ui/Button";
+import Loader from "~/components/ui/Loader";
 import { useDeleteTaskMutation } from "~/store/api";
 import { clearCurrentTask } from "~/store/boardSlice";
 import { selectCurrentTask } from "~/store/selectors";
 import { toggleDeleteTaskModal } from "~/store/uiSlice";
 
 const DeleteTask: React.FC = () => {
-  const [deleteTask, { isLoading, error, data }] = useDeleteTaskMutation();
+  const [deleteTask, { isLoading, error }] = useDeleteTaskMutation();
   const dispatch = useDispatch();
-
   const currentTask = useSelector(selectCurrentTask);
 
   const handleDelete = async () => {
@@ -24,7 +24,8 @@ const DeleteTask: React.FC = () => {
 
   if (error) return <p>Error</p>;
 
-  if (isLoading) return <p>Deleting task...</p>;
+  if (isLoading)
+    return <Loader message="Deleting Task..." color="#635fc7" size={16} />;
 
   return (
     <div className="z-[99999] flex flex-col gap-6">

--- a/src/components/modal/EditBoard.tsx
+++ b/src/components/modal/EditBoard.tsx
@@ -5,6 +5,7 @@ import { useDispatch, useSelector } from "react-redux";
 import AddIcon from "~/components/svg/AddIcon";
 import XIcon from "~/components/svg/XIcon";
 import Button from "~/components/ui/Button";
+import Loader from "~/components/ui/Loader";
 import { useEditBoardMutation } from "~/store/api";
 import { selectCurrentBoard } from "~/store/selectors";
 import { toggleEditBoardModal } from "~/store/uiSlice";
@@ -13,9 +14,9 @@ import { getRandColor } from "~/utils/getRandColor";
 
 const EditBoard = () => {
   const [columnsToDelete, setColumnsToDelete] = useState<string[]>([]);
-  const [editBoard, { isLoading, error, data }] = useEditBoardMutation();
-  const dispatch = useDispatch();
 
+  const [editBoard, { isLoading, error }] = useEditBoardMutation();
+  const dispatch = useDispatch();
   const currentBoard = useSelector(selectCurrentBoard);
 
   const {
@@ -57,7 +58,8 @@ const EditBoard = () => {
 
   if (error) return <div>Error</div>;
 
-  if (isLoading) return <p>Loading...</p>;
+  if (isLoading)
+    return <Loader message="Updating Board..." color="#635fc7" size={16} />;
 
   return (
     <div className="w-full space-y-6">

--- a/src/components/modal/EditTask.tsx
+++ b/src/components/modal/EditTask.tsx
@@ -5,6 +5,7 @@ import { useDispatch, useSelector } from "react-redux";
 import AddIcon from "~/components/svg/AddIcon";
 import XIcon from "~/components/svg/XIcon";
 import Button from "~/components/ui/Button";
+import Loader from "~/components/ui/Loader";
 import Select from "~/components/ui/Select";
 import { useEditTaskMutation } from "~/store/api";
 import { clearCurrentTask } from "~/store/boardSlice";
@@ -13,7 +14,7 @@ import { toggleEditTaskModal } from "~/store/uiSlice";
 import type { EditTaskInput, EditTaskRequest } from "~/types";
 
 const EditTask: React.FC = () => {
-  const [editTask, { isLoading, error, data }] = useEditTaskMutation();
+  const [editTask, { isLoading, error }] = useEditTaskMutation();
   const dispatch = useDispatch();
   const currentTask = useSelector(selectCurrentTask);
 
@@ -92,7 +93,8 @@ const EditTask: React.FC = () => {
 
   if (error) return <p>Error</p>;
 
-  if (isLoading) return <p>Updating task...</p>;
+  if (isLoading)
+    return <Loader message="Updating Task..." color="#635fc7" size={16} />;
 
   return (
     <div className="w-full space-y-6">

--- a/src/components/sidebar/MobileSidebar.tsx
+++ b/src/components/sidebar/MobileSidebar.tsx
@@ -9,6 +9,8 @@ import AddIcon from "~/components/svg/AddIcon";
 import BoardIcon from "~/components/svg/BoardIcon";
 import ChevronDownIcon from "~/components/svg/ChevronDownIcon";
 import LogoMobile from "~/components/svg/LogoMobile";
+import Loader from "~/components/ui/Loader";
+import { useGetBoardsQuery } from "~/store/api";
 import {
   selectBoards,
   selectCurrentBoard,
@@ -16,9 +18,9 @@ import {
 } from "~/store/selectors";
 import { toggleAddBoardModal, toggleMobileSidebar } from "~/store/uiSlice";
 
-const SidebarMobile: React.FC = () => {
+const MobileSidebar: React.FC = () => {
+  const { isLoading } = useGetBoardsQuery();
   const dispatch = useDispatch();
-
   const boards = useSelector(selectBoards);
   const currentBoard = useSelector(selectCurrentBoard);
   const showMobileSidebar = useSelector(selectShowMobileSidebar);
@@ -51,18 +53,20 @@ const SidebarMobile: React.FC = () => {
 
   return (
     <div className="flex w-fit cursor-pointer items-center gap-4 md:hidden">
-      <div>
-        <LogoMobile />
-      </div>
+      <LogoMobile />
       <div
         className="flex items-center gap-2"
         onClick={() => dispatch(toggleMobileSidebar())}
         ref={buttonRef}
       >
-        <h2 className="max-w-[8rem] capitalize">
-          {currentBoard?.name ?? "No Boards"}
+        <h2 className="w-36 capitalize">
+          {isLoading ? (
+            <Loader size={8} color="#635fc7" />
+          ) : (
+            currentBoard?.name ?? "No Boards"
+          )}
         </h2>
-        <div className="mt-1 cursor-pointer">
+        <div className={clsx("mt-1 cursor-pointer", isLoading && "hidden")}>
           <ChevronDownIcon
             className={clsx(
               "stroke-violet-700 transition",
@@ -111,4 +115,4 @@ const SidebarMobile: React.FC = () => {
   );
 };
 
-export default SidebarMobile;
+export default MobileSidebar;

--- a/src/components/subtask/Subtask.tsx
+++ b/src/components/subtask/Subtask.tsx
@@ -1,6 +1,7 @@
 import clsx from "clsx";
 
 import CheckIcon from "~/components/svg/CheckIcon";
+import Loader from "~/components/ui/Loader";
 import { useToggleSubtaskMutation } from "~/store/api";
 import { Subtask } from "~/types";
 
@@ -9,8 +10,7 @@ type SubtaskItemProps = {
 };
 
 const Subtask = ({ subtask }: SubtaskItemProps): JSX.Element => {
-  const [toggleSubtask, { isLoading, error, data }] =
-    useToggleSubtaskMutation();
+  const [toggleSubtask, { isLoading, error }] = useToggleSubtaskMutation();
 
   const handleToggle = async () => {
     try {
@@ -21,8 +21,6 @@ const Subtask = ({ subtask }: SubtaskItemProps): JSX.Element => {
   };
 
   if (error) return <p>Error</p>;
-
-  if (isLoading) return <p>Updating subtask...</p>;
 
   return (
     <li
@@ -45,7 +43,7 @@ const Subtask = ({ subtask }: SubtaskItemProps): JSX.Element => {
             : "text-black dark:text-white",
         )}
       >
-        {subtask.title}
+        {isLoading ? <Loader color="#635fc7" size={6} /> : subtask.title}
       </span>
     </li>
   );

--- a/src/components/ui/Loader.tsx
+++ b/src/components/ui/Loader.tsx
@@ -1,0 +1,21 @@
+import clsx from "clsx";
+import { PulseLoader } from "react-spinners";
+
+type LoaderProps = {
+  size?: number;
+  speedMultiplier?: number;
+  color?: string;
+  loading?: boolean;
+  message?: string;
+};
+
+const Loader: React.FC<LoaderProps> = (props) => {
+  return (
+    <div className="m-auto flex flex-col items-center gap-6">
+      <p className={clsx(props.message ? "" : "hidden")}>{props.message}</p>
+      <PulseLoader {...props} />
+    </div>
+  );
+};
+
+export default Loader;

--- a/src/pages/auth/index.tsx
+++ b/src/pages/auth/index.tsx
@@ -1,29 +1,45 @@
-import { useSession } from "next-auth/react";
+import { getSession, useSession, type GetSessionParams } from "next-auth/react";
 import { useRouter } from "next/router";
-import type { NextPage } from "next/types";
+import type { GetServerSideProps, NextPage } from "next/types";
 import { useEffect } from "react";
 
 import AuthPage from "~/components/auth/AuthPage";
+import Loader from "~/components/ui/Loader";
 
 const AuthForm: NextPage = () => {
-  const { data: session, status } = useSession();
+  const { status } = useSession();
   const router = useRouter();
 
   useEffect(() => {
     if (status === "authenticated") {
       void router.push("/boards");
     }
-  }, [session, status, router]);
-
-  if (status === "loading" || status === "authenticated") {
-    return <div>Loading...</div>;
-  }
+  }, [status, router]);
 
   return (
     <main className="h-screen w-screen flex-col items-center justify-center md:flex">
-      <AuthPage />
+      {false ? <Loader color="#635fc7" size={24} /> : <AuthPage />}
     </main>
   );
 };
 
 export default AuthForm;
+
+export const getServerSideProps: GetServerSideProps = async (
+  context: GetSessionParams,
+) => {
+  const session = await getSession(context);
+
+  if (session) {
+    return {
+      redirect: {
+        destination: "/boards",
+        permanent: false,
+      },
+    };
+  }
+
+  return {
+    props: {},
+  };
+};

--- a/src/pages/boards/index.tsx
+++ b/src/pages/boards/index.tsx
@@ -1,5 +1,5 @@
 import { useWindowSize } from "@uidotdev/usehooks";
-import { type GetSessionParams, getSession } from "next-auth/react";
+import { getSession, type GetSessionParams } from "next-auth/react";
 import type { GetServerSideProps, NextPage } from "next/types";
 import { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
@@ -10,6 +10,7 @@ import Header from "~/components/header/Header";
 import CurrentModal from "~/components/modal/CurrentModal";
 import Sidebar from "~/components/sidebar/Sidebar";
 import SidebarToggle from "~/components/sidebar/SidebarToggle";
+import Loader from "~/components/ui/Loader";
 import { useGetBoardsQuery } from "~/store/api";
 import { clearCurrentBoard, setCurrentBoard } from "~/store/boardSlice";
 import {
@@ -20,9 +21,9 @@ import {
 import { toggleMobileSidebar, toggleSidebar } from "~/store/uiSlice";
 
 const Boards: NextPage = () => {
-  const { data: boards, isLoading, isError } = useGetBoardsQuery();
   const size = useWindowSize();
 
+  const { data: boards, isLoading, isError } = useGetBoardsQuery();
   const dispatch = useDispatch();
   const currentBoard = useSelector(selectCurrentBoard);
   const showSidebar = useSelector(selectShowSidebar);
@@ -57,10 +58,6 @@ const Boards: NextPage = () => {
     }
   }, [boards, currentBoard, dispatch]);
 
-  if (isLoading) {
-    return <div>Loading boards...</div>;
-  }
-
   return (
     <>
       <Header />
@@ -73,7 +70,9 @@ const Boards: NextPage = () => {
           >
             <Sidebar />
           </div>
-          {boards?.length === 0 || currentBoard?.columns.length === 0 ? (
+          {isLoading ? (
+            <Loader message="Getting Your Data..." color="#635fc7" size={24} />
+          ) : boards?.length === 0 || currentBoard?.columns.length === 0 ? (
             <NoBoardOrEmptyBoard />
           ) : (
             <ColumnScrollContainer />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,42 +1,29 @@
-import {
-  getSession,
-  signIn,
-  useSession,
-  type GetSessionParams,
-} from "next-auth/react";
+import { getSession, signIn, type GetSessionParams } from "next-auth/react";
 import Image from "next/image";
 import type { GetServerSideProps, NextPage } from "next/types";
 
 import Button from "~/components/ui/Button";
 
 const Home: NextPage = () => {
-  const { data: session, status: sessionStatus } = useSession();
-
-  if (sessionStatus === "loading") {
-    return <div>Loading session...</div>;
-  }
-
-  if (!session) {
-    return (
-      <div className="grid h-screen">
-        <div className="flex flex-col items-center gap-16 place-self-center">
-          <div>
-            <Image
-              src="/assets/logo-main.webp"
-              alt="logo"
-              width={192}
-              height={192}
-              priority
-            />
-          </div>
-          <div className="flex flex-col items-center gap-6">
-            <span>You must be signed in to use this application!</span>
-            <Button onClick={() => signIn()}>Sign in</Button>
-          </div>
+  return (
+    <div className="flex h-screen items-center justify-center">
+      <div className="flex flex-col items-center gap-16 place-self-center">
+        <div>
+          <Image
+            src="/assets/logo-main.webp"
+            alt="logo"
+            width={192}
+            height={192}
+            priority
+          />
+        </div>
+        <div className="flex flex-col items-center gap-6">
+          <span>You must be signed in to use this application!</span>
+          <Button onClick={() => signIn()}>Sign in</Button>
         </div>
       </div>
-    );
-  }
+    </div>
+  );
 };
 
 export default Home;

--- a/src/pages/reports/index.tsx
+++ b/src/pages/reports/index.tsx
@@ -1,4 +1,5 @@
-import type { NextPage } from "next";
+import type { GetServerSideProps, NextPage } from "next";
+import { getSession, type GetSessionParams } from "next-auth/react";
 import { useRouter } from "next/router";
 import { useMemo, useState } from "react";
 import { useDispatch } from "react-redux";
@@ -15,8 +16,9 @@ import {
 
 const Report: NextPage = () => {
   const router = useRouter();
-  const dispatch = useDispatch();
   const [selectedBoardId, setSelectedBoardId] = useState("");
+
+  const dispatch = useDispatch();
   const { data: boards, isLoading, isError } = useGetBoardsQuery();
 
   const currentBoard = boards?.find((board) => board.id === selectedBoardId);
@@ -60,3 +62,22 @@ const Report: NextPage = () => {
 };
 
 export default Report;
+
+export const getServerSideProps: GetServerSideProps = async (
+  context: GetSessionParams,
+) => {
+  const session = await getSession(context);
+
+  if (!session) {
+    return {
+      redirect: {
+        destination: "/auth",
+        permanent: false,
+      },
+    };
+  }
+
+  return {
+    props: {},
+  };
+};


### PR DESCRIPTION
Refactors components to use Loader component
    
Each of the refactored pages/components previously used a placeholder div with "Loading..." as the indicator.

All components now use the same type of loader to convey a loading state. This includes:

- Initial page loads
- Header and sidebar have a loader in place of board name while loading
- Modal loading states when mutating a board or task
- Subtask item has a mini-loader when tapped on to toggle completion
- Navigating pages